### PR TITLE
Add some hooks

### DIFF
--- a/src/Api.res
+++ b/src/Api.res
@@ -40,9 +40,11 @@ module ReactHooks = {
   open Promise
   open Belt_Option
 
+  /// Subscribe to event and call user callback if event is received
   let useListen = (event: string, ~callback: Tauri.event => unit) => {
     let (unlisten: option<unit => unit>, setUnlisten) = React.useState(() => None)
 
+    /* Effect: subscribe to event. Call `unsubscribe` on cleanup. */
     React.useEffect1(() => {
       if unlisten->isNone {
         Tauri.listen(~event_name=event, ~callback)

--- a/src/Api.res
+++ b/src/Api.res
@@ -35,3 +35,25 @@ let promise_error_msg = (error: 'a): string => {
   | _ => `Some unknown error: ${error_stringified}`
   }
 }
+
+module ReactHooks = {
+  open Promise
+  open Belt_Option
+
+  let useListen = (event: string, ~callback: Tauri.event => unit) => {
+    let (unlisten: option<unit => unit>, setUnlisten) = React.useState(() => None)
+
+    React.useEffect1(() => {
+      if unlisten->isNone {
+        Tauri.listen(~event_name=event, ~callback)
+        ->then(unlisten => {
+          setUnlisten(_ => unlisten)
+          resolve()
+        })
+        ->ignore
+      }
+
+      unlisten
+    }, [unlisten])
+  }
+}

--- a/src/Api.res
+++ b/src/Api.res
@@ -44,8 +44,10 @@ module ReactHooks = {
   let useListen = (event: string, ~callback: Tauri.event => unit) => {
     let (unlisten: option<unit => unit>, setUnlisten) = React.useState(() => None)
 
+    let cb = React.useCallback1(callback, [])
+
     /* Effect: subscribe to event. Call `unsubscribe` on cleanup. */
-    React.useEffect1(() => {
+    React.useEffect3(() => {
       if unlisten->isNone {
         Tauri.listen(~event_name=event, ~callback)
         ->then(unlisten => {
@@ -56,6 +58,6 @@ module ReactHooks = {
       }
 
       unlisten
-    }, [unlisten])
+    }, (unlisten, event, cb))
   }
 }

--- a/src/App.res
+++ b/src/App.res
@@ -7,7 +7,7 @@ let make = () => {
   open Promise
   open MaterialUi
 
-  let (appState, setAppState) = useAppState()
+  let (dumpedState, setDumpedState) = useDumpedState()
   let config_lists = useConfigLists()
 
   let (is_started, set_is_started) = React.useState(() => false)
@@ -32,9 +32,9 @@ let make = () => {
     }
 
     let configs = if with_interface {
-      [appState.interface, appState.target]
+      [dumpedState.interface, dumpedState.target]
     } else {
-      [appState.board]
+      [dumpedState.board]
     }
 
     if configs->every(c => c->isSome) {
@@ -80,9 +80,9 @@ let make = () => {
             selector_name="board"
             items=config_lists.boards
             onChange={board => {
-              setAppState({...appState, board: board})
+              setDumpedState({...dumpedState, board: board})
             }}
-            selected=appState.board
+            selected=dumpedState.board
           />
         </Grid>
         <Grid item=true xs={Grid.Xs._12}>
@@ -91,7 +91,7 @@ let make = () => {
             doStart={() => start(~with_interface=false)}
             doStop=kill
             isStarted=is_started
-            isReady={() => appState.board->Belt.Option.isSome}
+            isReady={() => dumpedState.board->Belt.Option.isSome}
           />
         </Grid>
       </Grid>
@@ -103,9 +103,9 @@ let make = () => {
             selector_name="interface"
             items=config_lists.interfaces
             onChange={interface => {
-              setAppState({...appState, interface: interface})
+              setDumpedState({...dumpedState, interface: interface})
             }}
-            selected=appState.interface
+            selected=dumpedState.interface
           />
         </Grid>
         <Grid item=true xs={Grid.Xs._6}>
@@ -113,9 +113,9 @@ let make = () => {
             selector_name="target"
             items=config_lists.targets
             onChange={target => {
-              setAppState({...appState, target: target})
+              setDumpedState({...dumpedState, target: target})
             }}
-            selected=appState.target
+            selected=dumpedState.target
           />
         </Grid>
         <Grid item=true xs={Grid.Xs._12}>
@@ -125,7 +125,7 @@ let make = () => {
             doStop=kill
             isStarted=is_started
             isReady={_ => {
-              appState.target->Belt.Option.isSome && appState.interface->Belt.Option.isSome
+              dumpedState.target->Belt.Option.isSome && dumpedState.interface->Belt.Option.isSome
             }}
           />
         </Grid>

--- a/src/App.res
+++ b/src/App.res
@@ -2,6 +2,33 @@ open Api
 open AppHooks
 open AppTypes
 
+/// Component to render OpenOCD output
+///
+/// Accept openocd output string as a child. Render
+/// multiline text filed with child string inside.
+///
+module OpenocdOutput = {
+  open MaterialUi
+
+  let placeholder: string = "Openocd output..."
+  let max_row_count = TextField.RowsMax.int(18)
+
+  @react.component
+  let make = (~children: string) => {
+    <TextField
+      multiline=true
+      rowsMax=max_row_count
+      size=#Medium
+      variant=#Outlined
+      fullWidth=true
+      placeholder
+      disabled={children->Js.String2.length == 0}
+      value={TextField.Value.string(children)}
+    />
+  }
+}
+
+/// Main interface component
 @react.component
 let make = () => {
   open Promise
@@ -9,12 +36,10 @@ let make = () => {
 
   let (dumpedState, setDumpedState) = useDumpedState()
   let config_lists = useConfigLists()
+  let (openocd_output, set_openocd_output) = useOpenocdOutput()
 
   let (is_started, set_is_started) = React.useState(() => false)
-
   let (tab_panel_index, setTabPanelIndex) = React.useState(() => 0)
-
-  let (openocd_output, set_openocd_output) = useOpenocdOutput()
 
   /* Start OpenOCD process on backend with selected configs */
   let start = (~with_interface: bool) => {
@@ -154,16 +179,7 @@ let make = () => {
       <Grid item=true xs={Grid.Xs._12} />
     </Grid>
     <Paper elevation={MaterialUi_Types.Number.int(0)}>
-      <TextField
-        multiline=true
-        rowsMax={TextField.RowsMax.int(18)}
-        size=#Medium
-        variant=#Outlined
-        fullWidth=true
-        placeholder="Openocd output..."
-        disabled={openocd_output->Js.String2.length == 0}
-        value={TextField.Value.string(openocd_output)}
-      />
+      <OpenocdOutput> openocd_output </OpenocdOutput>
     </Paper>
   </>
 }

--- a/src/App.res
+++ b/src/App.res
@@ -1,131 +1,13 @@
 open Api
-
-type config_set_t = {
-  board: option<Openocd.config_t>,
-  interface: option<Openocd.config_t>,
-  target: option<Openocd.config_t>,
-}
-
-module Hooks = {
-  /// Subscribe to `openocd-output` and return OpenOCD output as string
-  ///
-  /// Returns:
-  ///   output: output of OpenOCD
-  ///   setOutput: setter to force set internal state
-  ///
-  let useOpenocdOutput = (): (string, string => unit) => {
-    let (output: string, setOutput) = React.useState(() => "")
-
-    /* Cut and append OpenOCD output to state by `openocd-output` event */
-    let openocd_output_cb = (e: Tauri.event) => {
-      let message = e.payload.message
-
-      let rec text_cuter = (text: string, length: int) => {
-        if text->Js.String2.length > length {
-          let second_line_position = text->Js.String2.indexOf("\n") + 1
-
-          if second_line_position == -1 {
-            text
-          } else {
-            let substring = text->Js.String2.substr(~from=second_line_position)
-            text_cuter(substring, length)
-          }
-        } else {
-          text
-        }
-      }
-
-      setOutput(output => {
-        (output ++ message)->text_cuter(5000)
-      })
-    }
-
-    Api.ReactHooks.useListen("openocd-output", ~callback=openocd_output_cb)
-
-    (output, string => {setOutput(_ => string)})
-  }
-
-  /// Load state the last saved app state, dump state, update state
-  ///
-  /// Store and provide access to config_set (set of current selected configs).
-  /// Returns:
-  ///   appState: config set
-  ///   setAppState: setter for config set
-  ///
-  let useAppState = (): (config_set_t, config_set_t => unit) => {
-    open Promise
-
-    /* App state (config set) */
-    let (config_set: config_set_t, setConfigSet) = React.useState(() => {
-      board: None,
-      interface: None,
-      target: None,
-    })
-
-    /* Dump an app state (config set) */
-    let dump_state = (config_set: config_set_t) => {
-      setConfigSet(_ => config_set)
-
-      let option_to_empty_cfg = (conf: option<Openocd.config_t>) => {
-        switch conf {
-        | Some(c) => c
-        | None => {name: "", path: ""}
-        }
-      }
-
-      let conf_to_save: Openocd.app_config_t = {
-        board: config_set.board->option_to_empty_cfg,
-        interface: config_set.interface->option_to_empty_cfg,
-        target: config_set.target->option_to_empty_cfg,
-      }
-
-      invoke_dump_state({dumped: conf_to_save})
-      ->then(_ => {
-        Js.Console.log("Dump selectors state")
-        Js.Console.log(conf_to_save)
-        resolve()
-      })
-      ->ignore
-    }
-
-    /* Effect: load the last saved configs once */
-    React.useEffect1(() => {
-      invoke_load_state()
-      ->then((conf: Openocd.app_config_t) => {
-        Js.Console.log("Load selectors state")
-        Js.Console.log(conf)
-
-        /* Turn empty config to option */
-        let as_option = (conf: Openocd.config_t) => {
-          if conf.name != "" {
-            Some(conf)
-          } else {
-            None
-          }
-        }
-
-        setConfigSet(_ => {
-          board: conf.board->as_option,
-          interface: conf.interface->as_option,
-          target: conf.target->as_option,
-        })
-        resolve()
-      })
-      ->ignore
-
-      None
-    }, [])
-
-    (config_set, dump_state)
-  }
-}
+open AppHooks
+open AppTypes
 
 @react.component
 let make = () => {
   open Promise
   open MaterialUi
 
-  let (appState, setAppState) = Hooks.useAppState()
+  let (appState, setAppState) = useAppState()
 
   let (config_lists: config_lists_t, setConfigLists) = React.useState(() => {
     boards: [],
@@ -137,8 +19,9 @@ let make = () => {
 
   let (tab_panel_index, setTabPanelIndex) = React.useState(() => 0)
 
-  let (openocd_output, set_openocd_output) = Hooks.useOpenocdOutput()
+  let (openocd_output, set_openocd_output) = useOpenocdOutput()
 
+  /* Effect: receive config lists */
   React.useEffect1(() => {
     invoke_get_config_lists()
     ->then(lists => {
@@ -158,8 +41,9 @@ let make = () => {
     open Belt_Array
     open Belt_Option
 
-    let unwrap_configs = (configs: array<option<Openocd.config_t>>) => {
-      configs->reduce([], (arr, el) => {
+    /* Convert array<option<'a>> to array<'a> with a None removing */
+    let unwrap_opt_array = (array: array<option<'a>>) => {
+      array->reduce([], (arr, el) => {
         switch el {
         | Some(el) => concat(arr, [el])
         | None => arr
@@ -177,7 +61,7 @@ let make = () => {
       set_openocd_output("")
 
       invoke_start({
-        configs: configs->unwrap_configs,
+        configs: configs->unwrap_opt_array,
       })
       ->then(ret => {
         Js.Console.log(`Invoking OpenOCD return: ${ret}`)
@@ -201,10 +85,12 @@ let make = () => {
     set_is_started(_ => false)
   }
 
+  /* Tab onChange handler, set current tab index */
   let handleTabPanelChange = (_, newValue: MaterialUi_Types.any) => {
     setTabPanelIndex(newValue->MaterialUi_Types.anyUnpack)
   }
 
+  /* Render tab content depending on index */
   let render_tab_content = (index: int) => {
     switch index {
     | 0 =>
@@ -269,6 +155,7 @@ let make = () => {
     }
   }
 
+  /* Render: app interface */
   <>
     <Grid container=true spacing=#V1 alignItems=#Stretch>
       <Grid item=true xs={Grid.Xs._3}>

--- a/src/App.res
+++ b/src/App.res
@@ -41,7 +41,7 @@ let make = () => {
     open Belt_Array
     open Belt_Option
 
-    /* Convert array<option<'a>> to array<'a> with a None removing */
+    /* Convert array<option<'a>> to array<'a> with None elements removed */
     let unwrap_opt_array = (array: array<option<'a>>) => {
       array->reduce([], (arr, el) => {
         switch el {

--- a/src/App.res
+++ b/src/App.res
@@ -28,6 +28,18 @@ module OpenocdOutput = {
   }
 }
 
+/// Render children if `currentIndex` is equal to `tabIndex`
+module TabContent = {
+  @react.component
+  let make = (~currentIndex: int, ~tabIndex: int, ~children: React.element) => {
+    if currentIndex == tabIndex {
+      children
+    } else {
+      <> </>
+    }
+  }
+}
+
 /// Main interface component
 @react.component
 let make = () => {
@@ -90,75 +102,65 @@ let make = () => {
     set_is_started(_ => false)
   }
 
-  /* Tab onChange handler, set current tab index */
-  let handleTabPanelChange = (_, newValue: MaterialUi_Types.any) => {
-    setTabPanelIndex(newValue->MaterialUi_Types.anyUnpack)
-  }
-
-  /* Render tab content depending on index */
-  let render_tab_content = (index: int) => {
-    switch index {
-    | 0 =>
-      <Grid container=true spacing=#V3 alignItems=#Stretch>
-        <Grid item=true xs={Grid.Xs._12}>
-          <BoardList
-            selector_name="board"
-            items=config_lists.boards
-            onChange={board => {
-              setDumpedState({...dumpedState, board: board})
-            }}
-            selected=dumpedState.board
-          />
-        </Grid>
-        <Grid item=true xs={Grid.Xs._12}>
-          <StartStopButton
-            itemName="board"
-            doStart={() => start(~with_interface=false)}
-            doStop=kill
-            isStarted=is_started
-            isReady={() => dumpedState.board->Belt.Option.isSome}
-          />
-        </Grid>
+  // Tab with board selector
+  let tab_board =
+    <Grid container=true spacing=#V3 alignItems=#Stretch>
+      <Grid item=true xs={Grid.Xs._12}>
+        <BoardList
+          selector_name="board"
+          items=config_lists.boards
+          onChange={board => {
+            setDumpedState({...dumpedState, board: board})
+          }}
+          selected=dumpedState.board
+        />
       </Grid>
-
-    | 1 =>
-      <Grid container=true spacing=#V3 alignItems=#Stretch>
-        <Grid item=true xs={Grid.Xs._6}>
-          <BoardList
-            selector_name="interface"
-            items=config_lists.interfaces
-            onChange={interface => {
-              setDumpedState({...dumpedState, interface: interface})
-            }}
-            selected=dumpedState.interface
-          />
-        </Grid>
-        <Grid item=true xs={Grid.Xs._6}>
-          <BoardList
-            selector_name="target"
-            items=config_lists.targets
-            onChange={target => {
-              setDumpedState({...dumpedState, target: target})
-            }}
-            selected=dumpedState.target
-          />
-        </Grid>
-        <Grid item=true xs={Grid.Xs._12}>
-          <StartStopButton
-            itemName="target with interface"
-            doStart={() => start(~with_interface=true)}
-            doStop=kill
-            isStarted=is_started
-            isReady={_ => {
-              dumpedState.target->Belt.Option.isSome && dumpedState.interface->Belt.Option.isSome
-            }}
-          />
-        </Grid>
+      <Grid item=true xs={Grid.Xs._12}>
+        <StartStopButton
+          itemName="board"
+          doStart={() => start(~with_interface=false)}
+          doStop=kill
+          isStarted=is_started
+          isReady={() => dumpedState.board->Belt.Option.isSome}
+        />
       </Grid>
+    </Grid>
 
-    | _ => <> </>
-    }
-  }
+  // Tab with target and interface selectors
+  let tab_target =
+    <Grid container=true spacing=#V3 alignItems=#Stretch>
+      <Grid item=true xs={Grid.Xs._6}>
+        <BoardList
+          selector_name="interface"
+          items=config_lists.interfaces
+          onChange={interface => {
+            setDumpedState({...dumpedState, interface: interface})
+          }}
+          selected=dumpedState.interface
+        />
+      </Grid>
+      <Grid item=true xs={Grid.Xs._6}>
+        <BoardList
+          selector_name="target"
+          items=config_lists.targets
+          onChange={target => {
+            setDumpedState({...dumpedState, target: target})
+          }}
+          selected=dumpedState.target
+        />
+      </Grid>
+      <Grid item=true xs={Grid.Xs._12}>
+        <StartStopButton
+          itemName="target with interface"
+          doStart={() => start(~with_interface=true)}
+          doStop=kill
+          isStarted=is_started
+          isReady={_ => {
+            dumpedState.target->Belt.Option.isSome && dumpedState.interface->Belt.Option.isSome
+          }}
+        />
+      </Grid>
+    </Grid>
 
   /* Render: app interface */
   <>
@@ -173,7 +175,10 @@ let make = () => {
       </Grid>
       <Grid item=true xs={Grid.Xs._9}>
         <Card elevation={MaterialUi_Types.Number.int(3)}>
-          <CardContent> {render_tab_content(tab_panel_index)} </CardContent>
+          <CardContent>
+            <TabContent currentIndex=tab_index tabIndex=0> {tab_board} </TabContent>
+            <TabContent currentIndex=tab_index tabIndex=1> {tab_target} </TabContent>
+          </CardContent>
         </Card>
       </Grid>
       <Grid item=true xs={Grid.Xs._12} />

--- a/src/App.res
+++ b/src/App.res
@@ -8,33 +8,13 @@ let make = () => {
   open MaterialUi
 
   let (appState, setAppState) = useAppState()
-
-  let (config_lists: config_lists_t, setConfigLists) = React.useState(() => {
-    boards: [],
-    interfaces: [],
-    targets: [],
-  })
+  let config_lists = useConfigLists()
 
   let (is_started, set_is_started) = React.useState(() => false)
 
   let (tab_panel_index, setTabPanelIndex) = React.useState(() => 0)
 
   let (openocd_output, set_openocd_output) = useOpenocdOutput()
-
-  /* Effect: receive config lists */
-  React.useEffect1(() => {
-    invoke_get_config_lists()
-    ->then(lists => {
-      setConfigLists(_ => lists)
-      resolve()
-    })
-    ->catch(err => {
-      Js.Console.error(Api.promise_error_msg(err))
-      resolve()
-    })
-    ->ignore
-    None
-  }, [])
 
   /* Start OpenOCD process on backend with selected configs */
   let start = (~with_interface: bool) => {

--- a/src/App.res
+++ b/src/App.res
@@ -28,28 +28,17 @@ module OpenocdOutput = {
   }
 }
 
-/// Render children if `currentIndex` is equal to `tabIndex`
-module TabContent = {
-  @react.component
-  let make = (~currentIndex: int, ~tabIndex: int, ~children: React.element) => {
-    if currentIndex == tabIndex {
-      children
-    } else {
-      <> </>
-    }
-  }
-}
-
 /// Main interface component
 @react.component
 let make = () => {
   open Promise
   open MaterialUi
+  open MaterialUiUtils
 
   let (dumpedState, setDumpedState) = useDumpedState()
   let config_lists = useConfigLists()
   let (openocd_output, set_openocd_output) = useOpenocdOutput()
-  let (tab_index, tabChangeHandler) = useMaterialUiTabIndex()
+  let (tab_index, tabChangeHandler) = MaterialUiUtils.Hooks.useMaterialUiTabIndex()
 
   let (is_started, set_is_started) = React.useState(() => false)
 

--- a/src/App.res
+++ b/src/App.res
@@ -37,9 +37,9 @@ let make = () => {
   let (dumpedState, setDumpedState) = useDumpedState()
   let config_lists = useConfigLists()
   let (openocd_output, set_openocd_output) = useOpenocdOutput()
+  let (tab_index, tabChangeHandler) = useMaterialUiTabIndex()
 
   let (is_started, set_is_started) = React.useState(() => false)
-  let (tab_panel_index, setTabPanelIndex) = React.useState(() => 0)
 
   /* Start OpenOCD process on backend with selected configs */
   let start = (~with_interface: bool) => {
@@ -165,7 +165,7 @@ let make = () => {
     <Grid container=true spacing=#V1 alignItems=#Stretch>
       <Grid item=true xs={Grid.Xs._3}>
         <Paper variant=#Outlined>
-          <Tabs orientation=#Vertical onChange=handleTabPanelChange value={tab_panel_index->Any}>
+          <Tabs orientation=#Vertical onChange=tabChangeHandler value={tab_index->Any}>
             <Tab label={"A predefined Board"->React.string} />
             <Tab label={"A Target with an Interface"->React.string} />
           </Tabs>

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -43,10 +43,10 @@ let useOpenocdOutput = (): (string, string => unit) => {
 /// Store and provide access to config_set (set of current selected configs).
 ///
 /// Returns:
-///   appState: config set
-///   setAppState: setter for config set
+///   config_set_t: config set
+///   config_set_t => unit: setter for config set
 ///
-let useAppState = (): (config_set_t, config_set_t => unit) => {
+let useDumpedState = (): (config_set_t, config_set_t => unit) => {
   open Api
   open Promise
 

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -113,3 +113,36 @@ let useAppState = (): (config_set_t, config_set_t => unit) => {
 
   (config_set, dump_state)
 }
+
+/// Receive config lists
+///
+/// Returns:
+///     config_lists_t — received config lists
+///
+let useConfigLists = () => {
+  open Api
+  open Promise
+
+  let (config_lists: config_lists_t, setConfigLists) = React.useState(() => {
+    boards: [],
+    interfaces: [],
+    targets: [],
+  })
+
+  /* Effect: receive config lists */
+  React.useEffect1(() => {
+    invoke_get_config_lists()
+    ->then(lists => {
+      setConfigLists(_ => lists)
+      resolve()
+    })
+    ->catch(err => {
+      Js.Console.error(Api.promise_error_msg(err))
+      resolve()
+    })
+    ->ignore
+    None
+  }, [])
+
+  config_lists
+}

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -146,3 +146,17 @@ let useConfigLists = () => {
 
   config_lists
 }
+
+/// Provide handler for a `MaterialUI.Tabs` component
+///
+/// Convert `Any` index type from `MaterialUi` lib and return it as a number.
+///
+let useMaterialUiTabIndex = () => {
+  let (tabIndex, setTabIndex) = React.useState(() => 0)
+
+  let tabChangeHandler = (_, newValue: MaterialUi_Types.any) => {
+    setTabIndex(newValue->MaterialUi_Types.anyUnpack)
+  }
+
+  (tabIndex, tabChangeHandler)
+}

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -1,0 +1,115 @@
+open AppTypes
+
+/// Subscribe to `openocd-output` and return OpenOCD output as string
+///
+/// Returns:
+///   output: output of OpenOCD
+///   setOutput: setter to force set internal state
+///
+let useOpenocdOutput = (): (string, string => unit) => {
+  let (output: string, setOutput) = React.useState(() => "")
+
+  /* Cut and append OpenOCD output to state by `openocd-output` event */
+  let openocd_output_cb = (e: Tauri.event) => {
+    let message = e.payload.message
+
+    let rec text_cuter = (text: string, length: int) => {
+      if text->Js.String2.length > length {
+        let second_line_position = text->Js.String2.indexOf("\n") + 1
+
+        if second_line_position == -1 {
+          text
+        } else {
+          let substring = text->Js.String2.substr(~from=second_line_position)
+          text_cuter(substring, length)
+        }
+      } else {
+        text
+      }
+    }
+
+    setOutput(output => {
+      (output ++ message)->text_cuter(5000)
+    })
+  }
+
+  Api.ReactHooks.useListen("openocd-output", ~callback=openocd_output_cb)
+
+  (output, string => {setOutput(_ => string)})
+}
+
+/// Load state the last saved app state, dump state, update state
+///
+/// Store and provide access to config_set (set of current selected configs).
+///
+/// Returns:
+///   appState: config set
+///   setAppState: setter for config set
+///
+let useAppState = (): (config_set_t, config_set_t => unit) => {
+  open Api
+  open Promise
+
+  /* App state (config set) */
+  let (config_set: config_set_t, setConfigSet) = React.useState(() => {
+    board: None,
+    interface: None,
+    target: None,
+  })
+
+  /* Dump an app state (config set) */
+  let dump_state = (config_set: config_set_t) => {
+    setConfigSet(_ => config_set)
+
+    let option_to_empty_cfg = (conf: option<Openocd.config_t>) => {
+      switch conf {
+      | Some(c) => c
+      | None => {name: "", path: ""}
+      }
+    }
+
+    let conf_to_save: Openocd.app_config_t = {
+      board: config_set.board->option_to_empty_cfg,
+      interface: config_set.interface->option_to_empty_cfg,
+      target: config_set.target->option_to_empty_cfg,
+    }
+
+    invoke_dump_state({dumped: conf_to_save})
+    ->then(_ => {
+      Js.Console.log("Dump selectors state")
+      Js.Console.log(conf_to_save)
+      resolve()
+    })
+    ->ignore
+  }
+
+  /* Effect: load the last saved configs once */
+  React.useEffect1(() => {
+    invoke_load_state()
+    ->then((conf: Openocd.app_config_t) => {
+      Js.Console.log("Load selectors state")
+      Js.Console.log(conf)
+
+      /* Turn empty config to option */
+      let as_option = (conf: Openocd.config_t) => {
+        if conf.name != "" {
+          Some(conf)
+        } else {
+          None
+        }
+      }
+
+      setConfigSet(_ => {
+        board: conf.board->as_option,
+        interface: conf.interface->as_option,
+        target: conf.target->as_option,
+      })
+      resolve()
+    })
+    ->ignore
+
+    None
+  }, [])
+
+  (config_set, dump_state)
+}

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -146,17 +146,3 @@ let useConfigLists = () => {
 
   config_lists
 }
-
-/// Provide handler for a `MaterialUI.Tabs` component
-///
-/// Convert `Any` index type from `MaterialUi` lib and return it as a number.
-///
-let useMaterialUiTabIndex = () => {
-  let (tabIndex, setTabIndex) = React.useState(() => 0)
-
-  let tabChangeHandler = (_, newValue: MaterialUi_Types.any) => {
-    setTabIndex(newValue->MaterialUi_Types.anyUnpack)
-  }
-
-  (tabIndex, tabChangeHandler)
-}

--- a/src/AppTypes.res
+++ b/src/AppTypes.res
@@ -1,0 +1,5 @@
+type config_set_t = {
+  board: option<Openocd.config_t>,
+  interface: option<Openocd.config_t>,
+  target: option<Openocd.config_t>,
+}

--- a/src/MaterialUiUtils.res
+++ b/src/MaterialUiUtils.res
@@ -1,0 +1,27 @@
+/// Render children if `currentIndex` is equal to `tabIndex`
+module TabContent = {
+  @react.component
+  let make = (~currentIndex: int, ~tabIndex: int, ~children: React.element) => {
+    if currentIndex == tabIndex {
+      children
+    } else {
+      <> </>
+    }
+  }
+}
+
+module Hooks = {
+  /// Provide handler for a `MaterialUI.Tabs` component
+  ///
+  /// Convert `Any` index type from `MaterialUi` lib and return it as a number.
+  ///
+  let useMaterialUiTabIndex = () => {
+    let (tabIndex, setTabIndex) = React.useState(() => 0)
+
+    let tabChangeHandler = (_, newValue: MaterialUi_Types.any) => {
+      setTabIndex(newValue->MaterialUi_Types.anyUnpack)
+    }
+
+    (tabIndex, tabChangeHandler)
+  }
+}


### PR DESCRIPTION
Extract some root (App) component logic into hooks:

- `ReactHooks.listen` — general hook to listen Tauri events
- `AppHooks.useOpenocdOutput` — receive OpenOCD output from backend
- `AppHooks.useDumpedState` — manage dumped configs
- `AppHooks.useConfigLists` — receive config lists from backend
- `MaterialUiUtils.Hooks.useMaterialUiTabIndex` — simplify `MaterialUI.Tabs` component index usage

Also some components added:

- `OpenocdOutput` — wrapper for `TextFiled` with OpenOCD output rendered
- `MaterialUiUtils.TabContent` — logic of selection tab content depending on current index (see `TabPanel` from [MaterialUI tabs examples](https://codesandbox.io/s/i6woo?file=/demo.js)).