### PR TITLE
FIX: Wrong config path resolving for shims like binaries

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.14"
 env_logger = "0.9.0"
 walkdir = "^2.3.2"
 confy = "^0.4.0"
+regex = "^1.5.4"
 
 [features]
 default = [ "custom-protocol" ]

--- a/src-tauri/src/openocd/proc.rs
+++ b/src-tauri/src/openocd/proc.rs
@@ -1,4 +1,5 @@
 use std::option::Option;
+use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use which::which;
 
@@ -28,5 +29,14 @@ pub fn start(config: &[Config]) -> Option<Child> {
         }
     } else {
         None
+    }
+}
+
+pub fn start_exec(exe_path: &Path, args: Vec<String>) -> Option<String> {
+    let out = Command::new(exe_path).args(args).output();
+
+    match out {
+        Ok(out) => Some(String::from_utf8_lossy(&out.stderr).to_string()),
+        Err(_) => None,
     }
 }


### PR DESCRIPTION
Add a hack to extract an executable path to OpenOCD in cases when binary, found by `which`, is a shim-like file.