### PR TITLE
Add notifications and events

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -18,6 +18,7 @@
         "@rescript/react",
         "rescript-material-ui",
         "rescript-material-ui-lab",
-        "@ryyppy/rescript-promise"
+        "@ryyppy/rescript-promise",
+        "rescript-jzon"
    ]
   }

--- a/package.json
+++ b/package.json
@@ -39,11 +39,12 @@
     "@rescript/react": "^0.10.3",
     "@ryyppy/rescript-promise": "^2.1.0",
     "@tauri-apps/api": "^1.0.0-beta.6",
+    "bs-platform": "^9.0.2",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
+    "rescript-jzon": "^1.2.0",
     "rescript-material-ui": "^2.1.2",
     "rescript-material-ui-lab": "^2.1.2",
-    "rollup-plugin-styles": "^3.14.1",
-    "bs-platform": "^9.0.2"
+    "rollup-plugin-styles": "^3.14.1"
   }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { version = "1.0.0-beta.4" }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_repr = "^0.1.7"
 tauri = { version = "1.0.0-beta.6", features = [] }
 which = "4.2.2"
 threadpool = "1.8.1"

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -1,0 +1,6 @@
+use serde::Serialize;
+
+#[derive(Clone, Serialize)]
+pub struct Payload {
+    pub message: String,
+}

--- a/src-tauri/src/cmd.rs
+++ b/src-tauri/src/cmd.rs
@@ -3,17 +3,13 @@ use std::io::{BufRead, BufReader};
 use std::sync::{Arc, Mutex};
 use tauri::Window;
 
+use crate::api;
 use crate::config::AppConfig;
+use crate::error::ErrorMsg;
+use crate::notification;
 use crate::openocd::config::{Config, ConfigsSet};
 use crate::openocd::proc as openocd;
 use crate::state::State;
-use crate::error::ErrorMsg;
-
-#[derive(Clone, serde::Serialize)]
-struct Payload {
-    message: String,
-}
-
 
 /// Return a struct with three lists of `Config`
 ///
@@ -78,7 +74,11 @@ pub fn kill(state: tauri::State<State>) -> Result<String, ErrorMsg> {
 /// ```
 ///
 #[tauri::command]
-pub fn start(configs: Vec<Config>, state: tauri::State<State>, window: Window) -> Result<String, ErrorMsg> {
+pub fn start(
+    configs: Vec<Config>,
+    state: tauri::State<State>,
+    window: Window,
+) -> Result<String, ErrorMsg> {
     info!(
         r#"Start openocd with configs: "{:?}""#,
         configs
@@ -106,6 +106,8 @@ pub fn start(configs: Vec<Config>, state: tauri::State<State>, window: Window) -
                     let reader = BufReader::new(stderr);
 
                     info!("OpenOCD started!");
+                    notification::send(&window, "OpenOCD started!", notification::Level::Info);
+
                     reader
                         .lines()
                         .filter_map(|line| line.ok())
@@ -113,14 +115,19 @@ pub fn start(configs: Vec<Config>, state: tauri::State<State>, window: Window) -
                             window
                                 .emit(
                                     "openocd-output",
-                                    Payload {
+                                    api::Payload {
                                         message: format!("{}\n", line),
                                     },
                                 )
-                                .unwrap();
+                                .unwrap_or_else(|e| {
+                                    error!("Error occurred while OpenOCD running: {}", e);
+                                });
+
                             info!("-- {}", line);
                         });
+
                     warn!("OpenOCD stopped!");
+                    notification::send(&window, "OpenOCD stopped!", notification::Level::Warn);
                 }
             });
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,8 @@ mod config;
 mod openocd;
 mod state;
 mod error;
+mod notification;
+mod api;
 
 fn main() {
     ::std::env::set_var("RUST_LOG", "debug");

--- a/src-tauri/src/notification.rs
+++ b/src-tauri/src/notification.rs
@@ -2,11 +2,12 @@ use tauri::Window;
 
 use crate::api;
 
-#[derive(Clone, serde::Serialize)]
+#[derive(Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]
+#[repr(u8)]
 pub enum Level {
-    Info,
-    Warn,
-    Error,
+    Info = 0,
+    Warn = 1,
+    Error = 2,
 }
 
 #[derive(Clone, serde::Serialize)]
@@ -18,7 +19,7 @@ pub struct Notification {
 pub fn send(window: &Window, msg: &str, lvl: Level) {
     window
         .emit(
-            "event",
+            "notification",
             api::Payload {
                 message: serde_json::to_string(&Notification {
                     level: lvl,

--- a/src-tauri/src/notification.rs
+++ b/src-tauri/src/notification.rs
@@ -1,0 +1,31 @@
+use tauri::Window;
+
+use crate::api;
+
+#[derive(Clone, serde::Serialize)]
+pub enum Level {
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub struct Notification {
+    pub level: Level,
+    pub message: String,
+}
+
+pub fn send(window: &Window, msg: &str, lvl: Level) {
+    window
+        .emit(
+            "event",
+            api::Payload {
+                message: serde_json::to_string(&Notification {
+                    level: lvl,
+                    message: msg.into(),
+                })
+                .expect("Fail to serialize event!"),
+            },
+        )
+        .expect("Fail to send event!");
+}

--- a/src-tauri/src/openocd/event.rs
+++ b/src-tauri/src/openocd/event.rs
@@ -17,7 +17,7 @@ pub struct Event {
 pub fn send(window: &Window, event: Kind) {
     window
         .emit(
-            "event",
+            "openocd-event",
             api::Payload {
                 message: serde_json::to_string(&Event { event }).expect("Fail to serialize event!"),
             },

--- a/src-tauri/src/openocd/event.rs
+++ b/src-tauri/src/openocd/event.rs
@@ -2,10 +2,11 @@ use tauri::Window;
 
 use crate::api;
 
-#[derive(Clone, serde::Serialize)]
+#[derive(Clone, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]
+#[repr(u8)]
 pub enum Kind {
-    Start,
-    Stop,
+    Start = 0,
+    Stop = 1,
 }
 
 #[derive(Clone, serde::Serialize)]

--- a/src-tauri/src/openocd/event.rs
+++ b/src-tauri/src/openocd/event.rs
@@ -1,0 +1,25 @@
+use tauri::Window;
+
+use crate::api;
+
+#[derive(Clone, serde::Serialize)]
+pub enum Kind {
+    Start,
+    Stop,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub struct Event {
+    pub event: Kind,
+}
+
+pub fn send(window: &Window, event: Kind) {
+    window
+        .emit(
+            "event",
+            api::Payload {
+                message: serde_json::to_string(&Event { event }).expect("Fail to serialize event!"),
+            },
+        )
+        .expect("Fail to send event!");
+}

--- a/src-tauri/src/openocd/mod.rs
+++ b/src-tauri/src/openocd/mod.rs
@@ -1,2 +1,3 @@
 pub mod proc;
 pub mod config;
+pub mod event;

--- a/src/Api.res
+++ b/src/Api.res
@@ -35,12 +35,10 @@ module Notification = {
       switch level {
       | Some(level) => {level_num: level_num, message: message, level: level}->Ok
       | _ =>
-        Error(
-          #UnexpectedJsonValue(
-            [],
-            `"level": expected a number 0..2, current is ${level_num->Js.Int.toString}`,
-          ),
-        )
+        #UnexpectedJsonValue(
+          [],
+          `"level": expected a number 0..2, current is ${level_num->Js.Int.toString}`,
+        )->Error
       }
     },
     Jzon.field("level", Jzon.int),

--- a/src/Api.res
+++ b/src/Api.res
@@ -13,6 +13,15 @@ type notification_t = {
   message: string,
 }
 
+module Codecs = {
+  let notification = Jzon.object2(
+    ({level, message}) => (level, message),
+    ((level, message)) => {level, message}->Ok,
+    Jzon.field("level", Jzon.int),
+    Jzon.field("message", Jzon.string),
+  )
+}
+
 let invoke_get_config_lists = (): Promise.t<config_lists_t> => Tauri.invoke("get_config_lists")
 
 let invoke_start = (cfgs: configs): Promise.t<string> => Tauri.invoke1("start", cfgs)

--- a/src/Api.res
+++ b/src/Api.res
@@ -8,6 +8,11 @@ type config_lists_t = {
   targets: array<Openocd.config_t>,
 }
 
+type notification_t = {
+  level: int,
+  message: string,
+}
+
 let invoke_get_config_lists = (): Promise.t<config_lists_t> => Tauri.invoke("get_config_lists")
 
 let invoke_start = (cfgs: configs): Promise.t<string> => Tauri.invoke1("start", cfgs)
@@ -59,5 +64,25 @@ module ReactHooks = {
 
       unlisten
     }, (unlisten, event, cb))
+  }
+
+  /// Generic hook to recevice "typed" events
+  ///
+  /// Subscribe to event and try to convert event.payload.message to 'a on receive
+  ///
+  /// Arguments:
+  ///   event — event subscribe to
+  ///   toPayloadType — converts string JSON to 'a
+  ///
+  /// Returns
+  ///   event structure of type 'a or None, if conversion failed
+  let useTypedListen = (event: string, toPayloadType: string => option<'a>): option<'a> => {
+    let (payload: option<'a>, setPayload) = React.useState(() => None)
+
+    useListen(event, ~callback=e => {
+      setPayload(_ => toPayloadType(e.payload.message))
+    })
+
+    payload
   }
 }

--- a/src/App.res
+++ b/src/App.res
@@ -41,7 +41,7 @@ let make = () => {
   let (tab_index, tabChangeHandler) = MaterialUiUtils.Hooks.useMaterialUiTabIndex()
 
   let (is_started, set_is_started) = React.useState(() => false)
-
+  
   /* Start OpenOCD process on backend with selected configs */
   let start = (~with_interface: bool) => {
     open Belt_Array

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -168,30 +168,12 @@ let useConfigLists = () => {
   config_lists
 }
 
-/// Subscribe to `notification` event and return notification_t object on event receive
+/// Subscribe to `notification` event and return Notification.t object on event receive
 let useOpenocdNotification = (): option<Api.Notification.t> => {
-  // Convert JSON string to Api.notification_t
-  let toNotification = (json_string: string): option<Api.Notification.t> => {
-    let json = Utils.Json.parse(json_string)
+  Api.ReactHooks.useTypedListen("notification", Api.Notification.codec)
+}
 
-    switch json {
-    | Some(json) => {
-        let decode_result = json->Jzon.decodeWith(Api.Notification.codec)
-
-        switch decode_result {
-        | Ok(result) => Some(result)
-        | Error(e) => {
-            %log.error(`Bad notification message: ${e->Jzon.DecodingError.toString}`)
-            None
-          }
-        }
-      }
-    | _ => None
-    }
-  }
-
-  // Subscribe to event
-  let notification = Api.ReactHooks.useTypedListen("notification", toNotification)
-
-  notification
+/// Subscribe to `openocd-event` event and return OpenocdEvent.t object on event receive
+let useOpenocdEvent = (): option<Api.OpenocdEvent.t> => {
+  Api.ReactHooks.useTypedListen("openocd-event", Api.OpenocdEvent.codec)
 }

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -152,3 +152,46 @@ let useConfigLists = () => {
 
   config_lists
 }
+
+/// Subscribe to `notification` event and return notification_t object on event receive
+let useOpenocdNotification = (): option<Api.notification_t> => {
+  open Belt_Option
+
+  // Convert JSON string to Api.notification_t
+  let toNotification = (json_string: string): option<Api.notification_t> => {
+    let json = Utils.Json.parse(json_string)
+
+    switch json {
+    | Some(json) => {
+        let dict = Utils.Json.toObject(json)
+
+        dict->flatMap(dict => {
+          let level =
+            dict
+            ->Js.Dict.get("level")
+            ->flatMap(level => Utils.Json.toInt(level))
+            ->map(level => level)
+
+          let message =
+            dict
+            ->Js.Dict.get("message")
+            ->flatMap(message => Utils.Json.toString(message))
+            ->map(message => message)
+
+          let event: option<Api.notification_t> = switch (level, message) {
+          | (Some(level), Some(message)) => Some({level: level, message: message})
+          | _ => None
+          }
+
+          event
+        })
+      }
+    | _ => None
+    }
+  }
+
+  // Subscribe to event
+  let notification = Api.ReactHooks.useTypedListen("notification", toNotification)
+
+  notification
+}

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -181,7 +181,7 @@ let useOpenocdNotification = (): option<Api.notification_t> => {
         switch decode_result {
         | Ok(result) => Some(result)
         | Error(e) => {
-            Js.Console.error(`Bad notification message: ${e->Jzon.DecodingError.toString}`)
+            %log.error(`Bad notification message: ${e->Jzon.DecodingError.toString}`)
             None
           }
         }

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -169,14 +169,14 @@ let useConfigLists = () => {
 }
 
 /// Subscribe to `notification` event and return notification_t object on event receive
-let useOpenocdNotification = (): option<Api.notification_t> => {
+let useOpenocdNotification = (): option<Api.Notification.t> => {
   // Convert JSON string to Api.notification_t
-  let toNotification = (json_string: string): option<Api.notification_t> => {
+  let toNotification = (json_string: string): option<Api.Notification.t> => {
     let json = Utils.Json.parse(json_string)
 
     switch json {
     | Some(json) => {
-        let decode_result = json->Jzon.decodeWith(Api.Codecs.notification)
+        let decode_result = json->Jzon.decodeWith(Api.Notification.codec)
 
         switch decode_result {
         | Ok(result) => Some(result)

--- a/src/Utils/Utils.res
+++ b/src/Utils/Utils.res
@@ -1,0 +1,1 @@
+module Json = Utils_Json;

--- a/src/Utils/Utils_Json.res
+++ b/src/Utils/Utils_Json.res
@@ -26,7 +26,7 @@ let parse = (str: string): option<Js.Json.t> => {
 }
 
 module Jzon = {
-  /// Return codec to convert encode/decode int enum
+  /// Return codec to encode/decode int enum
   let int_enum = (enumToInt: 'a => int, intToEnum: int => option<'a>) =>
     Jzon.custom(
       x => Jzon.float->Jzon.encode(enumToInt(x)->Belt.Int.toFloat),

--- a/src/Utils/Utils_Json.res
+++ b/src/Utils/Utils_Json.res
@@ -36,7 +36,15 @@ module Jzon = {
           switch x->Belt.Float.toInt->intToEnum {
           | Some(x) => Ok(x)
           | None =>
-            Error(#UnexpectedJsonType([], "int_enum (unexpected underlying enum value)", json))
+            Error(
+              #UnexpectedJsonType(
+                [],
+                `int_enum (unexpected underlying enum value: ${x
+                  ->Belt.Float.toInt
+                  ->Js.Int.toString})`,
+                json,
+              ),
+            )
           }
         | None => Error(#UnexpectedJsonType([], "string", json))
         },

--- a/src/Utils/Utils_Json.res
+++ b/src/Utils/Utils_Json.res
@@ -1,0 +1,29 @@
+let toInt = (obj: Js.Json.t): option<int> => {
+  switch Js.Json.classify(obj) {
+  | Js.Json.JSONNumber(obj) => Some(obj->Belt.Float.toInt)
+  | _ => None
+  }
+}
+
+let toString = (obj: Js.Json.t): option<string> => {
+  switch Js.Json.classify(obj) {
+  | Js.Json.JSONString(obj) => Some(obj)
+  | _ => None
+  }
+}
+
+let toObject = (obj: Js.Json.t): option<Js.Dict.t<Js.Json.t>> => {
+  switch Js.Json.classify(obj) {
+  | Js.Json.JSONObject(obj) => Some(obj)
+  | _ => None
+  }
+}
+
+let parse = (str: string): option<Js.Json.t> => {
+    try Some(Js.Json.parseExn(str)) catch {
+    | _ => {
+        Js.Console.error("Error parsing event JSON string")
+        None
+      }
+    }
+}

--- a/src/Utils/Utils_Json.res
+++ b/src/Utils/Utils_Json.res
@@ -20,10 +20,7 @@ let toObject = (obj: Js.Json.t): option<Js.Dict.t<Js.Json.t>> => {
 }
 
 let parse = (str: string): option<Js.Json.t> => {
-    try Some(Js.Json.parseExn(str)) catch {
-    | _ => {
-        Js.Console.error("Error parsing event JSON string")
-        None
-      }
-    }
+  try Some(Js.Json.parseExn(str)) catch {
+  | _ => None
+  }
 }


### PR DESCRIPTION
### Rust

Backend now can send some messages using Tauri evens. Added [events about OpenOCD start/stop ](https://github.com/ila-embsys/justrunmydebugger/pull/9/files#diff-b876209231781c3173311dce0ff6b5b1750d8b2e5199013274fc990d83958cc5) and [notifications](https://github.com/ila-embsys/justrunmydebugger/pull/9/files#diff-d823b5ed96c6b762b6204fa6250d62a773158255bbda94247638c716f0ef14bb). JSON string is used as an event payload, and it must be decoded on GUI side.


### Rescript

Added generic hook [`useTypedListen`](https://github.com/ila-embsys/justrunmydebugger/pull/9/files#diff-e8897fff47b51a88de6c0d843329296e5ec40f616df12999e2ffc03e374ef244R105) to listen for Tauri events and convert it to corresponding "typed" struct (payload.message field must contain JSON string). [Jzon](https://github.com/nkrkv/jzon) library is used for a conversion. Custom codec [`int_enum`](https://github.com/ila-embsys/justrunmydebugger/pull/9/files#diff-23f3c70f1390972c740c2f370269c6dcc85118a19b92bef2aa366d196d025639R30) was written for an int enum conversion.

Added [hooks](https://github.com/ila-embsys/justrunmydebugger/pull/9/files#diff-c536e110b9a149a1e70b62e24c1d2495e726a2b610e50fa1d68aa5c76b6db115):
- `useOpenocdNotification` — listens `notification` Tauti events and retuns them as struct with `Notification.t` type;
- `useOpenocdEvent` — listens `openocd-event` and retuns `Event.t`.