### PR TITLE
Remove extra JSON convention in event based communications

### DIFF
--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -1,20 +1,8 @@
 use log::error;
 use serde::Serialize;
 
-#[derive(Clone, Serialize)]
-pub struct Payload {
-    pub message: String,
-}
-
-pub fn send_raw(window: &tauri::Window, event: &str, msg: &str) {
-    window
-        .emit(
-            event,
-            Payload {
-                message: msg.to_string(),
-            },
-        )
-        .unwrap_or_else(|e| {
-            error!("Error occurred while sending event: {}", e);
-        });
+pub fn send_raw<T: Serialize>(window: &tauri::Window, event: &str, payload: T) {
+    window.emit(event, payload).unwrap_or_else(|e| {
+        error!("Error occurred while sending event: {}", e);
+    });
 }

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -7,7 +7,6 @@ use std::{
 use tauri::Window;
 use threadpool::ThreadPool;
 
-use crate::api;
 use crate::{
     config::AppConfig,
     error::ErrorMsg,
@@ -31,7 +30,7 @@ impl App {
 
     /// Start openocd as process with provided configs as args
     ///
-    /// Started process emits event `openocd-output` on every received line of
+    /// Started process emits event `openocd.output` on every received line of
     /// openocd output to stderr. Return status as a string.
     ///
     /// List of configs can be retrieved with `get_config_list`.
@@ -141,8 +140,7 @@ impl App {
                     .lines()
                     .filter_map(|line| line.ok())
                     .for_each(|line| {
-                        api::send_raw(&window, "openocd-output", format!("{}\n", line).as_str());
-                        info!("-- {}", line);
+                        crate::openocd::output::send(&window, format!("{}\n", line));
                     });
 
                 App::send_event(&window, openocd_event::Kind::Stop, None)

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -141,6 +141,7 @@ impl App {
                     .filter_map(|line| line.ok())
                     .for_each(|line| {
                         crate::openocd::output::send(&window, format!("{}\n", line));
+                        info!("-- {}", line);
                     });
 
                 App::send_event(&window, openocd_event::Kind::Stop, None)

--- a/src-tauri/src/cmd.rs
+++ b/src-tauri/src/cmd.rs
@@ -28,7 +28,7 @@ pub fn kill(state: tauri::State<State>, window: Window) -> Result<String, ErrorM
 
 /// Start openocd as process with provided configs as args
 ///
-/// Started process emits event `openocd-output` on every received line of
+/// Started process emits event `openocd.output` on every received line of
 /// openocd output to stderr. Return status as a string.
 ///
 /// List of configs can be retrieved with `get_config_list`.

--- a/src-tauri/src/notification.rs
+++ b/src-tauri/src/notification.rs
@@ -20,11 +20,9 @@ pub fn send(window: &Window, msg: &str, lvl: Level) {
     api::send_raw(
         window,
         "notification",
-        serde_json::to_string(&Notification {
+        Notification {
             level: lvl,
             message: msg.into(),
-        })
-        .expect("Fail to serialize event!")
-        .as_str(),
+        },
     );
 }

--- a/src-tauri/src/openocd/event.rs
+++ b/src-tauri/src/openocd/event.rs
@@ -15,11 +15,5 @@ pub struct Event {
 }
 
 pub fn send(window: &Window, event: Kind) {
-    api::send_raw(
-        window,
-        "openocd-event",
-        serde_json::to_string(&Event { event })
-            .expect("Fail to serialize event!")
-            .as_str(),
-    );
+    api::send_raw(window, "openocd.event", Event { event });
 }

--- a/src-tauri/src/openocd/mod.rs
+++ b/src-tauri/src/openocd/mod.rs
@@ -1,4 +1,5 @@
 pub mod proc;
 pub mod config;
 pub mod event;
+pub mod output;
 mod paths;

--- a/src-tauri/src/openocd/output.rs
+++ b/src-tauri/src/openocd/output.rs
@@ -1,0 +1,10 @@
+use tauri::Window;
+
+#[derive(Clone, serde::Serialize)]
+pub struct Output {
+    pub line: String,
+}
+
+pub fn send(window: &Window, line: String) {
+    crate::api::send_raw(window, "openocd.output", Output { line });
+}

--- a/src/Tauri.res
+++ b/src/Tauri.res
@@ -10,7 +10,7 @@ external invoke2: (string, 'a, 'b) => Promise.t<'data> = "invoke"
 @module("@tauri-apps/api/tauri")
 external invoke3: (string, 'a, 'b, 'c) => Promise.t<'data> = "invoke"
 
-type payload = {message: string}
+type payload = Js.Json.t
 type event = {name: string, payload: payload}
 
 @module("@tauri-apps/api/event")

--- a/src/Utils/Utils_Json.res
+++ b/src/Utils/Utils_Json.res
@@ -49,4 +49,26 @@ module Jzon = {
         | None => Error(#UnexpectedJsonType([], "string", json))
         },
     )
+
+  /// Return codec to encode/decode string enum
+  let string_enum = (enumToString: 'a => string, stringToEnum: string => option<'a>) =>
+    Jzon.custom(
+      x => Jzon.string->Jzon.encode(enumToString(x)),
+      json =>
+        switch json->Js.Json.decodeString {
+        | Some(x) =>
+          switch x->stringToEnum {
+          | Some(x) => Ok(x)
+          | None =>
+            Error(
+              #UnexpectedJsonType(
+                [],
+                `string_enum (unexpected underlying enum value: ${x})`,
+                json,
+              ),
+            )
+          }
+        | None => Error(#UnexpectedJsonType([], "string", json))
+        },
+    )
 }


### PR DESCRIPTION
Tauri has already been converting any event payload to JSON and back. So it's not necessary to convert it by hands. All stuff connected with conversion payload to string and back was removed in back and front.

Also, events were renamed to "openocd.<something>" instead of "openocd-<something>".

Future rust code refactoring is needed to make `openocd` crate less patchy.

`string_enum` codec added FFU.