### PR TITLE
Settings refactoring

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,10 +1,17 @@
 use serde::{Deserialize, Serialize};
 
-use crate::openocd::config::Config;
+use crate::gitpod::config::Config as GitpodConfig;
+use crate::openocd::config::Config as OpenocdConfig;
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct OpenocdConfigSet {
+    board: OpenocdConfig,
+    interface: OpenocdConfig,
+    target: OpenocdConfig,
+}
 
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct AppConfig {
-    board: Config,
-    interface: Config,
-    target: Config,
+    openocd: OpenocdConfigSet,
+    gitpod: GitpodConfig,
 }

--- a/src-tauri/src/gitpod/config.rs
+++ b/src-tauri/src/gitpod/config.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct Config {
+    instance_id: String,
+    hostname: String,
+}

--- a/src-tauri/src/gitpod/mod.rs
+++ b/src-tauri/src/gitpod/mod.rs
@@ -1,2 +1,3 @@
 pub mod events;
 pub mod proc;
+pub mod config;

--- a/src/Api.res
+++ b/src/Api.res
@@ -1,20 +1,20 @@
-type configs = {configs: array<Openocd.config_t>}
-type config_type = {configType: string}
-type dump_state_t = {dumped: Openocd.app_config_t}
+type configs_t = {configs: array<Openocd.config_file_t>}
+type settings_t = {gitpod: AppTypes.gitpod_settings_t, openocd: Openocd.openocd_config_t}
+type dump_state_t = {dumped: settings_t}
 
 type config_lists_t = {
-  boards: array<Openocd.config_t>,
-  interfaces: array<Openocd.config_t>,
-  targets: array<Openocd.config_t>,
+  boards: array<Openocd.config_file_t>,
+  interfaces: array<Openocd.config_file_t>,
+  targets: array<Openocd.config_file_t>,
 }
 
 let invoke_get_config_lists = (): Promise.t<config_lists_t> => Tauri.invoke("get_config_lists")
 
-let invoke_start = (cfgs: configs): Promise.t<string> => Tauri.invoke1("start", cfgs)
+let invoke_start = (cfgs: configs_t): Promise.t<string> => Tauri.invoke1("start", cfgs)
 
 let invoke_kill = (): Promise.t<string> => Tauri.invoke("kill")
 
-let invoke_load_state = (): Promise.t<Openocd.app_config_t> => Tauri.invoke("load_state")
+let invoke_load_state = (): Promise.t<settings_t> => Tauri.invoke("load_state")
 
 type gitpod_hostname_t = option<string>
 type gitpod_config_t = {

--- a/src/Api.res
+++ b/src/Api.res
@@ -1,5 +1,5 @@
 type configs_t = {configs: array<Openocd.config_file_t>}
-type settings_t = {gitpod: AppTypes.gitpod_settings_t, openocd: Openocd.openocd_config_t}
+type settings_t = {gitpod: AppTypes.gitpod_settings_t, openocd: Openocd.config_t}
 type dump_state_t = {dumped: settings_t}
 
 type config_lists_t = {

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -109,7 +109,7 @@ let useSettings = (): (option<Settings.t>, Settings.t => unit) => {
       }
     }
 
-    let openocd_config: Openocd.openocd_config_t = {
+    let openocd_config: Openocd.config_t = {
       board: settings.openocd.board->option_to_empty_cfg,
       interface: settings.openocd.interface->option_to_empty_cfg,
       target: settings.openocd.target->option_to_empty_cfg,

--- a/src/AppHooks.res
+++ b/src/AppHooks.res
@@ -42,100 +42,6 @@ let useOpenocdOutput = (): (string, string => unit) => {
   (output, string => {setOutput(_ => string)})
 }
 
-/// Load state the last saved app state, dump state, update state
-///
-/// Store and provide access to config_set (set of current selected configs).
-///
-/// Returns:
-///   config_set_t: config set
-///   config_set_t => unit: setter for config set
-///
-let useDumpedState = (): (config_set_t, config_set_t => unit) => {
-  open Api
-  open Promise
-
-  /* App state (config set) */
-  let (config_set: config_set_t, setConfigSet) = React.useState(() => {
-    board: None,
-    interface: None,
-    target: None,
-  })
-
-  /* Dump an app state (config set) */
-  let dump_state = (config_set: config_set_t) => {
-    setConfigSet(_ => config_set)
-
-    let option_to_empty_cfg = (conf: option<Openocd.config_t>) => {
-      switch conf {
-      | Some(c) => c
-      | None => {name: "", path: ""}
-      }
-    }
-
-    let conf_to_save: Openocd.app_config_t = {
-      board: config_set.board->option_to_empty_cfg,
-      interface: config_set.interface->option_to_empty_cfg,
-      target: config_set.target->option_to_empty_cfg,
-    }
-
-    invoke_dump_state({dumped: conf_to_save})
-    ->then(_ => {
-      %log.info(
-        "Dump selectors state:"
-        ("conf_to_save", conf_to_save)
-      )
-      resolve()
-    })
-    ->catch(err => {
-      %log.error(
-        "Dump selectors state raise an exception"
-        ("Api.promise_error_msg(err)", Api.promise_error_msg(err))
-      )
-      resolve()
-    })
-    ->ignore
-  }
-
-  /* Effect: load the last saved configs once */
-  React.useEffect1(() => {
-    invoke_load_state()
-    ->then((conf: Openocd.app_config_t) => {
-      %log.info(
-        "Load selectors state:"
-        ("conf", conf)
-      )
-
-      /* Turn empty config to option */
-      let as_option = (conf: Openocd.config_t) => {
-        if conf.name != "" {
-          Some(conf)
-        } else {
-          None
-        }
-      }
-
-      setConfigSet(_ => {
-        board: conf.board->as_option,
-        interface: conf.interface->as_option,
-        target: conf.target->as_option,
-      })
-      resolve()
-    })
-    ->catch(err => {
-      %log.error(
-        "Load selectors state raise an exception"
-        ("Api.promise_error_msg(err)", Api.promise_error_msg(err))
-      )
-      resolve()
-    })
-    ->ignore
-
-    None
-  }, [])
-
-  (config_set, dump_state)
-}
-
 /// Receive config lists
 ///
 /// Returns:
@@ -173,6 +79,96 @@ let useConfigLists = () => {
   }, [])
 
   (is_configs_found, config_lists)
+}
+
+/// Load the last app settings, dump settings, update settings
+///
+/// Store and provide access to app settings.
+///
+/// Returns:
+///   Settings.t: the app settings
+///   Settings.t => unit: setter for the settings
+///
+let useSettings = (): (option<Settings.t>, Settings.t => unit) => {
+  open Api
+  open Promise
+
+  /* Setting state */
+  let (settings: option<Settings.t>, setSettings) = React.useState(() => {
+    None
+  })
+
+  /* Dump an app settings */
+  let dump_settings = (settings: Settings.t) => {
+    setSettings(_ => Some(settings))
+
+    let option_to_empty_cfg = (conf: option<Openocd.config_file_t>) => {
+      switch conf {
+      | Some(c) => c
+      | None => {name: "", path: ""}
+      }
+    }
+
+    let openocd_config: Openocd.openocd_config_t = {
+      board: settings.openocd.board->option_to_empty_cfg,
+      interface: settings.openocd.interface->option_to_empty_cfg,
+      target: settings.openocd.target->option_to_empty_cfg,
+    }
+
+    invoke_dump_state({dumped: {gitpod: settings.gitpod, openocd: openocd_config}})
+    ->then(_ => {
+      Js.Console.info2("Dump app settings:", settings)
+      resolve()
+    })
+    ->catch(err => {
+      %log.error(
+        "Dump selectors state raise an exception"
+        ("Api.promise_error_msg(err)", Api.promise_error_msg(err))
+      )
+      resolve()
+    })
+    ->ignore
+  }
+
+  /* Effect: load the last saved settings once */
+  React.useEffect1(() => {
+    invoke_load_state()
+    ->then((settings: settings_t) => {
+      Js.Console.info2("Load app settings:", settings)
+
+      /* Turn empty config to option */
+      let as_option = (conf: Openocd.config_file_t) => {
+        if conf.name != "" {
+          Some(conf)
+        } else {
+          None
+        }
+      }
+
+      setSettings(_ => Some({
+        openocd: {
+          board: settings.openocd.board->as_option,
+          interface: settings.openocd.interface->as_option,
+          target: settings.openocd.target->as_option,
+        },
+        gitpod: settings.gitpod,
+      }))
+
+      resolve()
+    })
+    ->catch(err => {
+      %log.error(
+        "Load selectors state raise an exception"
+        ("Api.promise_error_msg(err)", Api.promise_error_msg(err))
+      )
+      resolve()
+    })
+    ->ignore
+
+    None
+  }, [])
+
+  (settings, dump_settings)
 }
 
 /// Subscribe to `app://notification` event and return Notification.t object on event receive

--- a/src/AppTypes.res
+++ b/src/AppTypes.res
@@ -4,7 +4,7 @@ type gitpod_settings_t = {
 }
 
 module Settings = {
-  type t = {openocd: Openocd.openocd_config_set_t, gitpod: gitpod_settings_t}
+  type t = {openocd: Openocd.config_set_t, gitpod: gitpod_settings_t}
 
   let default = (): t => {
     {

--- a/src/AppTypes.res
+++ b/src/AppTypes.res
@@ -1,5 +1,19 @@
-type config_set_t = {
-  board: option<Openocd.config_t>,
-  interface: option<Openocd.config_t>,
-  target: option<Openocd.config_t>,
+type gitpod_settings_t = {
+  instance_id: string,
+  hostname: string,
+}
+
+module Settings = {
+  type t = {openocd: Openocd.openocd_config_set_t, gitpod: gitpod_settings_t}
+
+  let default = (): t => {
+    {
+      openocd: {
+        board: None,
+        interface: None,
+        target: None,
+      },
+      gitpod: {instance_id: "", hostname: ""},
+    }
+  }
 }

--- a/src/BoardList.res
+++ b/src/BoardList.res
@@ -1,19 +1,19 @@
 open MuiLab
 
-// Tricky convert `MaterialUi.Autocomplete.Value.t` to `Openocd.config_t`
-external asOcdConfig: Autocomplete.Value.t => Openocd.config_t = "%identity"
+// Tricky convert `MaterialUi.Autocomplete.Value.t` to `AppTypes.openocd_config_file_t`
+external asOcdConfig: Autocomplete.Value.t => Openocd.config_file_t = "%identity"
 
 @react.component
 let make = (
   ~selector_name: string,
-  ~items: array<Openocd.config_t>,
-  ~onChange: option<Openocd.config_t> => unit,
-  ~selected: option<Openocd.config_t>,
+  ~items: array<Openocd.config_file_t>,
+  ~onChange: option<Openocd.config_file_t> => unit,
+  ~selected: option<Openocd.config_file_t>,
 ) => {
   open Belt
   open Mui
 
-  let optionRender = (b: Openocd.config_t, _) => {
+  let optionRender = (b: Openocd.config_file_t, _) => {
     <Typography> {b.name->React.string} </Typography>
   }
 
@@ -81,7 +81,7 @@ let make = (
         value={selected->Mui.Any.make}
         key={`${selector_name}-${selected_name}`}
         options={items->Array.map(v => v->Mui.Any.make)}
-        getOptionLabel={(item: Openocd.config_t) => item.name}
+        getOptionLabel={(item: Openocd.config_file_t) => item.name}
         renderInput
         onChange=handleChangeItem
         renderOption=optionRender

--- a/src/BoardList.res
+++ b/src/BoardList.res
@@ -1,6 +1,6 @@
 open MuiLab
 
-// Tricky convert `MaterialUi.Autocomplete.Value.t` to `AppTypes.openocd_config_file_t`
+// Tricky convert `MaterialUi.Autocomplete.Value.t` to `Openocd.config_file_t`
 external asOcdConfig: Autocomplete.Value.t => Openocd.config_file_t = "%identity"
 
 @react.component

--- a/src/GitpodButton.res
+++ b/src/GitpodButton.res
@@ -1,4 +1,6 @@
-let useNotification = (enqueueSnackbar) => {
+let useNotification = (useSnackbar: unit => Notistack.ProviderContext.t) => {
+  let {enqueueSnackbar, _} = useSnackbar()
+
   (~msg: string, ~level: Notistack.VariantType.t) => {
     let _ = enqueueSnackbar(
       ~message=msg->React.string,
@@ -17,8 +19,7 @@ let make = () => {
   let (state, dispatch) = React.useReducer(Gitpod.State.reducer, Gitpod.State.initial_state)
   let (instance_id, setInstanceId) = React.useState(() => "")
   let (hostname, setHostname) = React.useState(() => "")
-  let {enqueueSnackbar, _} = Notistack.useSnackbar()
-  let sendNotification = useNotification(enqueueSnackbar)
+  let sendNotification = useNotification(Notistack.useSnackbar)
 
   /* Invoke Gitpod connection process */
   React.useEffect1(() => {

--- a/src/Openocd.res
+++ b/src/Openocd.res
@@ -3,13 +3,13 @@ type config_file_t = {
   path: string,
 }
 
-type openocd_config_set_t = {
+type config_set_t = {
   board: option<config_file_t>,
   interface: option<config_file_t>,
   target: option<config_file_t>,
 }
 
-type openocd_config_t = {
+type config_t = {
   board: config_file_t,
   interface: config_file_t,
   target: config_file_t,

--- a/src/Openocd.res
+++ b/src/Openocd.res
@@ -1,10 +1,16 @@
-type config_t = {
+type config_file_t = {
   name: string,
   path: string,
 }
 
-type app_config_t = {
-  board: config_t,
-  interface: config_t,
-  target: config_t,
+type openocd_config_set_t = {
+  board: option<config_file_t>,
+  interface: option<config_file_t>,
+  target: option<config_file_t>,
+}
+
+type openocd_config_t = {
+  board: config_file_t,
+  interface: config_file_t,
+  target: config_file_t,
 }

--- a/src/ReactExt/ReactExt.res
+++ b/src/ReactExt/ReactExt.res
@@ -1,0 +1,1 @@
+module Context = ReactExt_Context

--- a/src/ReactExt/ReactExt_Context.res
+++ b/src/ReactExt/ReactExt_Context.res
@@ -1,0 +1,34 @@
+// Original writer: Rickard Natt och Dag
+// Source: https://dev.to/believer/rescript-using-usecontext-in-reasonreact-19p3
+
+/// Generic type to provide description of a context internal data structure
+/// and it's initial value
+module type Config = {
+  type context
+  let defaultValue: context
+}
+
+/// Create a standard React context module parametrized with Config generic module type
+///
+/// This is a generic way to create contexts, there `context` type provides
+/// stored in context data structure. Provider will be generated according to
+/// recommendations in official ReScript docs.
+/// See https://rescript-lang.org/docs/react/latest/context.
+module Make = (Config: Config) => {
+  let t = React.createContext(Config.defaultValue)
+
+  module Provider = {
+    let make = React.Context.provider(t)
+
+    @obj
+    external makeProps: (
+      ~value: Config.context,
+      ~children: React.element,
+      ~key: string=?,
+      unit,
+    ) => {"value": Config.context, "children": React.element} = ""
+  }
+
+  /// Helper func to avoid using `React.useContext`
+  let use = () => React.useContext(t)
+}

--- a/src/Root.res
+++ b/src/Root.res
@@ -1,0 +1,14 @@
+/// Root component
+///
+/// Render App only after settings was loaded from backend.
+///
+@react.component
+let make = () => {
+  let (settings, saveSettings) = AppHooks.useSettings()
+
+  switch settings {
+  | Some(settings) =>
+    <SettingsContext.Provider initial=settings> <App saveSettings /> </SettingsContext.Provider>
+  | None => <MuiExt.Loading display=true />
+  }
+}

--- a/src/SettingsContext.res
+++ b/src/SettingsContext.res
@@ -1,0 +1,61 @@
+/// App settings container type
+type state_t = AppTypes.Settings.t
+
+/// Variant with update settings actions
+module Update = {
+  type t =
+    | Board(option<Openocd.config_file_t>)
+    | Target(option<Openocd.config_file_t>)
+    | Interface(option<Openocd.config_file_t>)
+    | Id(string)
+    | Hostname(string)
+    | All(state_t)
+}
+
+/// Update settings action type alias
+type action_t = Update.t
+
+/// Specific context for this App settings management
+///
+/// See ReactExt.Context.
+///
+module Context = {
+  include ReactExt.Context.Make({
+    type context = (state_t, action_t => unit)
+    let defaultValue = (AppTypes.Settings.default(), _ => ())
+  })
+}
+
+/// Context provider to read and write settings of the application
+///
+/// Should be used with hook `useSettings` to extract an initial
+/// settings value and save the settings to memory.
+///
+/// See
+/// - https://rescript-lang.org/docs/react/latest/context
+/// - https://dev.to/believer/rescript-using-usecontext-in-reasonreact-19p3
+module Provider = {
+  /// Update app settings structure on every action
+  /// Arguments:
+  ///   state - previous state
+  ///   action - update action
+  let updater = (state: state_t, action): state_t => {
+    switch action {
+    | Update.Board(board) => {...state, openocd: {...state.openocd, board: board}}
+    | Update.Target(target) => {...state, openocd: {...state.openocd, target: target}}
+    | Update.Interface(interface) => {
+        ...state,
+        openocd: {...state.openocd, interface: interface},
+      }
+    | Update.Id(id) => {...state, gitpod: {...state.gitpod, instance_id: id}}
+    | Update.Hostname(hostname) => {...state, gitpod: {...state.gitpod, hostname: hostname}}
+    | Update.All(state) => state
+    }
+  }
+
+  @react.component
+  let make = (~children, ~initial) => {
+    let (state, dispatch) = React.useReducer(updater, initial)
+    <Context.Provider value=(state, dispatch)> children </Context.Provider>
+  }
+}

--- a/src/StartButton.res
+++ b/src/StartButton.res
@@ -1,13 +1,13 @@
 @react.component
 let make = (
   ~item_name: string="config",
-  ~config_items: array<option<Openocd.config_t>>,
-  ~doStart: array<Openocd.config_t> => unit,
+  ~config_items: array<option<Openocd.config_file_t>>,
+  ~doStart: array<Openocd.config_file_t> => unit,
   ~doStop,
   ~isStarted: bool,
   ~isReady: unit => bool=() => true,
 ) => {
-  let buttonMsg = (board: option<Openocd.config_t>) => {
+  let buttonMsg = (board: option<Openocd.config_file_t>) => {
     if isStarted {
       "Stop"
     } else {

--- a/src/Utils/Utils_String.res
+++ b/src/Utils/Utils_String.res
@@ -3,7 +3,7 @@ let empty = (s: string) => {
   s->String.length == 0
 }
 
-/// Convert sting to option<string>
+/// Convert string to option<string>
 ///
 /// Return None if string empty
 let to_option = (s: string): option<string> => {
@@ -13,4 +13,11 @@ let to_option = (s: string): option<string> => {
     else {
         None
     }
+}
+
+/// Convert option<string> to string
+///
+/// Return empty string if None
+let from_option = (s: option<string>): string => {
+    s->Belt.Option.getWithDefault("")
 }

--- a/src/main.res
+++ b/src/main.res
@@ -1,6 +1,6 @@
 %%raw(`import "@fontsource/roboto/400.css";`)
 
 switch ReactDOM.querySelector("#root") {
-| Some(root) => ReactDOM.render(<App />, root)
+| Some(root) => ReactDOM.render(<Root />, root)
 | None => ()
 }


### PR DESCRIPTION
Recreate settings (aka config in the past) as [React.Context](https://ru.reactjs.org/docs/context.html) to make settings avaliable to use and update on all application levels, including `GitpodButton`. Now, rescript part of the application has `Root` component to initialize and provide `SettingsContext `to all other components. Settings can be updated using react reducer technic from inner components. Mostly it's the App component, but Gitpod button is going to use it too.

Add gitpod settings to the app settings struct.

The most of the settings related types were renamed or moved in UI.